### PR TITLE
Bugfix: Updated createTexture function in index*.js

### DIFF
--- a/demo/js/index.js
+++ b/demo/js/index.js
@@ -12621,7 +12621,7 @@ function createTexture(gl, source, i) {
   gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR);
   gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR);
 
-  updateTexture(gl, source);
+  if(source != null) updateTexture(gl, source);
 
   return texture;
 }

--- a/demo/js/index2.js
+++ b/demo/js/index2.js
@@ -4814,7 +4814,7 @@ function createTexture(gl, source, i) {
   gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR);
   gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR);
 
-  updateTexture(gl, source);
+  if(source != null) updateTexture(gl, source);
 
   return texture;
 }

--- a/demo/js/index3.js
+++ b/demo/js/index3.js
@@ -4832,7 +4832,7 @@ function createTexture(gl, source, i) {
   gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR);
   gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR);
 
-  updateTexture(gl, source);
+  if(source != null) updateTexture(gl, source);
 
   return texture;
 }


### PR DESCRIPTION
createTexture(gl, source, i) has a responsibility of creating
GL Texture object with source data.
creating texture object can be done even if the source is null, except
calling texImage2D which is for uploading the buffer data to gpu memory.

Fix solving this issue:
https://github.com/codrops/RainEffect/issues/11